### PR TITLE
Add missing callback to addAppSources

### DIFF
--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -271,18 +271,16 @@ module.exports = function(grunt) {
             var appOutputDir;
 
             if (isPlatformRequested(requestedPlatform, "darwin")) {
-
                 appOutputDir = path.join(buildOutputDir, "Atom.app", "Contents","Resources", "app");
             }
             else if (isPlatformRequested(requestedPlatform, "win32") ||
                      isPlatformRequested(requestedPlatform, "linux")) {
 
                 appOutputDir = path.join(buildOutputDir, "resources", "app");
-        }
+            }
             else {
-
                 grunt.log.fail("Failed to copy app, platform not understood: " + requestedPlatform);
-        }
+            }
 
             wrench.copyDirSyncRecursive(options.app_dir, appOutputDir, {
                 forceDelete: true,
@@ -294,5 +292,7 @@ module.exports = function(grunt) {
 
             grunt.log.ok("Build for platform " + requestedPlatform + " located at " + buildOutputDir);
         });
+
+        callback();
     }
 };


### PR DESCRIPTION
https://github.com/entropi/grunt-atom-shell-app-builder/issues/7 was caused by the callback call missing in `addAppSources`. This commit fixes this issue.
