### PR TITLE
Option to force the use of a cached version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ Required: `no`
 
 Where downloads of the pre-built binaries should be stored.
 
+#### options.force_cached_version
+Type: `boolean`
+Default value: `false`
+Required: `no`
+
+If `force_cached_version` is set to `true` then the task will use use the version in the `cache` directory that matches the correct file name (i.e. `atom-shell-v0.20.4-win32-ia32.zip`) even if the zip file is a different size than what has been officially released. This will allow you to make custom changes to the build of atom-shell (such as changing the icon of the `exe` or editing the `Info.plist` in `Atom.app`). If this is set to `false` (which is the default) then anything in the cache directory must match the correct file name and file size. It is recommended that this be used in conjunction with `options.atom_shell_version`.
+
+
+
 #### options.app_dir
 Type: `String`
 Default value: `app`

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
                 build_dir: "build",
                 cache_dir: "cache",
                 app_dir: "app",
+                force_cached_version:false,
                 platforms: [process.platform]
             });
 
@@ -183,7 +184,7 @@ module.exports = function(grunt) {
         if (fs.existsSync(saveLocation))
         {
             var stats = fs.statSync(saveLocation);
-            if (stats.isFile() && (stats.size == assetSize))
+            if (options.force_cached_version || (stats.isFile() && (stats.size == assetSize)))
             {
                 grunt.log.ok(" Found cached download of " + assetName);
                 callback();


### PR DESCRIPTION
Right now, the task checks whether the cached version of the atom-shell binaries have the correct name and the same size as what is on github. As a workaround for changing the icons of the `exe` and the name of the app on Mac ([some options discussed here](https://github.com/atom/atom-shell/blob/b94375c7940678229757591388b035662339667c/docs/tutorial/application-distribution.md)), I wanted to edit the icon of the `atom.exe` using [Resource Hacker](http://download.cnet.com/Resource-Hacker/3000-2352_4-10178587.html). I then zipped the cached binary and gave it the same name and wanted my grunt task to use this custom version. Instead it downloaded the latest version from github because the zip file had changed size.

If this feature is something you want in the package, feel free to merge the pull request. If not, don't worry about it.