### PR TITLE
Add file globbing for finding project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# Webstorm IDE settings
+.idea
+
 # Dependency directory
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Required: `no`
 
 Where downloads of the pre-built binaries should be stored.
 
-#### options.app_dir
-Type: `String`
-Default value: `app`
+#### options.src
+Type: `String Array`
+Default value: `app/**/*`
 Required: `no`
 
-Where application source is located. This will be copied to the app directory for each platform build.
+Where application source is located using [simple-glob](https://github.com/jedmao/simple-glob). This will be copied to the app directory for each platform build.
 
 #### options.platforms
 Type: `String Array`

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "grunt": "^0.4.5"
   },
   "dependencies": {
-    "request": "^2.36.0",
-    "lodash": "^2.4.1",
     "async": "^0.9.0",
-    "wrench": "^1.5.8",
+    "decompress-zip": "0.0.6",
+    "fs-extra": "^0.16.5",
+    "lodash": "^2.4.1",
     "progress": "^1.1.5",
-    "decompress-zip": "0.0.6"
+    "request": "^2.36.0",
+    "simple-glob": "^0.1.0",
+    "wrench": "^1.5.8"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Adding file globbing with 'simple-glob' adds more flexibility for project structures that do not contain all of the release files in one top-level directory.
