### PR TITLE
Fix asar generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "async": "^0.9.0",
     "wrench": "^1.5.8",
     "progress": "^1.1.5",
-    "decompress-zip": "0.0.6"
+    "decompress-zip": "0.0.6",
+    "fs-extra": "0.23.0"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -8,7 +8,7 @@
  */
 
 var path = require('path');
-var fs = require('fs');
+var fs = require('fs-extra');
 var request = require('request');
 var async = require('async');
 var wrench = require('wrench');
@@ -345,7 +345,7 @@ module.exports = function(grunt) {
               });
             } else if (appDirStats.isFile() && options.app_dir.indexOf('.asar') !== -1) {
               grunt.log.ok("App is a file")
-              fs.createReadStream(options.app_dir).pipe(fs.createWriteStream(appOutputDir+'.asar'));
+              fs.copySync(options.app_dir, appOutputDir+'.asar');
             } else {
               grunt.log.error('Shared directory must be either a directory or an ASAR archive.')
             }


### PR DESCRIPTION
On some platforms, with a large application, the function can return before finishing the copy. Using copySync from fs-extra fixes this issue.
