### PR TITLE
Added: Support for asar with unpacked directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-electron-app-builder
 
-Helps build electron baed applications for mac, win and linux with grunt. It will download the prebuilt binaries for either the latest or a specific version, unpack them, and add your application source to the extracted distirbution.
+Helps build electron based applications for mac, win and linux with grunt. It will download the prebuilt binaries for either the latest or a specific version, unpack them, and add your application source to the extracted distribution.
 
 ## Getting Started
 Install this grunt plugin with: `npm install grunt-electron-app-builder`
@@ -36,7 +36,7 @@ Type: `String`
 Default value: `most recent release`
 Required: `no`
 
-The version of electron you want to use (e.g., `'v0.24.0'`). [Here is a list](https://github.com/atom/electron/releases) of available releases. If not specified, it will query github for the latest release.
+The version of electron you want to use (e.g., `'v0.32.0'`). [Here is a list](https://github.com/atom/electron/releases) of available releases. If not specified, it will query github for the latest release.
 
 #### options.build_dir
 Type: `String`
@@ -65,7 +65,7 @@ Type: `String Array`
 Default value: `[ 'HostPlatform' ]`
 Required: `no`
 
-The platforms to download and build packages for. Supported platforms are `'darwin'`, `'win32'`, `'linux32'`, and `'linux64'` (`'linux'` works as well for backwards compatibility, and maps to linux32). If ommitted, defaults to the host platform. 
+The platforms to download and build packages for. Supported platforms are `'darwin'`, `'win32'`, `'linux32'`, and `'linux64'` (`'linux'` works as well for backwards compatibility, and maps to linux32). If omitted, defaults to the host platform. 
 
 Note that building `'darwin'` packages on a windows host is currently unsupported due to the format of the darwin electron zip, which includes symlinks.
 

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
               
               if(fs.existsSync(p+".asar.unpacked")) {
                 grunt.log.success("app unpacked dir exists");
-                fs.chmodSync(p, 0755);
+                fs.chmodSync(p+".asar.unpacked", 0755);
               }
 
               fs.chmodSync(path.join(options.build_dir, platform, "electron", "electron"), 0757)

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -75,15 +75,20 @@ module.exports = function(grunt) {
         async.eachSeries(options.platforms, function(platform, localcallback) {
           if (['linux', 'linux32', 'linux64'].indexOf(platform) != -1 && process.platform == 'linux') {
               var p = path.join(options.build_dir, platform, "electron", "resources", "app")
-              grunt.log.success(p)
+            
               if(fs.existsSync(p)) {
-                grunt.log.success("app dir exists")
-                fs.chmodSync(p, 0755)
+                grunt.log.success("app dir exists");
+                fs.chmodSync(p, 0755);
               }
 
               if(fs.existsSync(p+".asar")) {
-                grunt.log.success("app archive exists")
-                fs.chmodSync(p+".asar", 0755)
+                grunt.log.success("app archive exists");
+                fs.chmodSync(p+".asar", 0755);
+              }
+              
+              if(fs.existsSync(p+".asar.unpacked")) {
+                grunt.log.success("app unpacked dir exists");
+                fs.chmodSync(p, 0755);
               }
 
               fs.chmodSync(path.join(options.build_dir, platform, "electron", "electron"), 0757)
@@ -344,8 +349,12 @@ module.exports = function(grunt) {
                   inflateSymlinks: true
               });
             } else if (appDirStats.isFile() && options.app_dir.indexOf('.asar') !== -1) {
-              grunt.log.ok("App is a file")
+              grunt.log.ok("App is packed as .asar")
               fs.copySync(options.app_dir, appOutputDir+'.asar');
+              
+              if (fs.existsSync(options.app_dir + ".unpacked")) {
+                fs.copySync(options.app_dir + ".unpacked", appOutputDir+'.asar.unpacked');
+              }
             } else {
               grunt.log.error('Shared directory must be either a directory or an ASAR archive.')
             }

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -332,6 +332,8 @@ module.exports = function(grunt) {
               if (err) return grunt.log.fail(err);
               callback(err, options);
             });
+          } else {
+            callback(null, options);
           }
         });
     }

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
                 build_dir: "build",
                 cache_dir: "cache",
                 app_dir: "app",
+                force_cached_version: false,
                 platforms: [plat]
             });
 
@@ -236,7 +237,7 @@ module.exports = function(grunt) {
         if (fs.existsSync(saveLocation))
         {
             var stats = fs.statSync(saveLocation);
-            if (stats.isFile() && (stats.size == assetSize))
+            if (options.force_cached_version || (stats.isFile() && (stats.size == assetSize)))
             {
                 grunt.log.ok(" Found cached download of " + assetName);
                 callback();

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -63,9 +63,7 @@ module.exports = function(grunt) {
                 extractReleases,
                 removeDefaultApp,
                 addAppSources,
-                function(callback) {
-                    setLinuxPermissions(options, callback);
-                },
+                setLinuxPermissions,
             ], function(err) { if (err) throw err; done(); }
 
         );
@@ -332,7 +330,7 @@ module.exports = function(grunt) {
           if (fs.existsSync(defaultApp)) {
             fs.remove(defaultApp, function (err) {
               if (err) return grunt.log.fail(err);
-              callback();
+              callback(err, options);
             });
           }
         });
@@ -384,6 +382,6 @@ module.exports = function(grunt) {
             grunt.log.ok("Build for platform " + requestedPlatform + " located at " + buildOutputDir);
         });
 
-        callback();
+        callback(null, options);
     }
 };

--- a/tasks/build-atom-shell-app-task.js
+++ b/tasks/build-atom-shell-app-task.js
@@ -61,6 +61,7 @@ module.exports = function(grunt) {
                 verifyTagAndGetReleaseInfo,
                 downloadReleases,
                 extractReleases,
+                removeDefaultApp,
                 addAppSources,
                 function(callback) {
                     setLinuxPermissions(options, callback);
@@ -314,6 +315,27 @@ module.exports = function(grunt) {
     //
     function isPlatformRequested(requestedPlatform, platform) {
         return requestedPlatform.indexOf(platform) != -1;
+    }
+    
+    function removeDefaultApp(options, callback)
+    {
+        grunt.log.subhead("Removing default_app.")
+      
+        options.platforms.forEach(function (requestedPlatform) {
+          var buildOutputDir = path.join(options.build_dir, requestedPlatform, "electron");
+          var defaultApp = path.join(buildOutputDir, "resources", "default_app");
+
+          if (isPlatformRequested(requestedPlatform, "darwin")) {
+              defaultApp = path.join(buildOutputDir, "Electron.app", "Contents","Resources", "default_app");
+          }
+
+          if (fs.existsSync(defaultApp)) {
+            fs.remove(defaultApp, function (err) {
+              if (err) return grunt.log.fail(err);
+              callback();
+            });
+          }
+        });
     }
 
     function addAppSources(options, callback)


### PR DESCRIPTION
When using an asar archive it is possible to have an `app.asar.unpacked` directory generated, see:

https://github.com/atom/asar/pull/25

If this is detected it should be packaged alongside the asar archive.
